### PR TITLE
Fix Supervisor command name

### DIFF
--- a/.github/workflows/deploy-to-server.yml
+++ b/.github/workflows/deploy-to-server.yml
@@ -22,4 +22,4 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
-          script: sudo supervisorctl restart streamlit && streamlit cache clear
+          script: sudo supervisorctl restart picker && streamlit cache clear

--- a/.github/workflows/upgrade-streamlit.yml
+++ b/.github/workflows/upgrade-streamlit.yml
@@ -11,4 +11,4 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
-          script: pip install --upgrade streamlit && sudo supervisorctl restart streamlit && streamlit cache clear
+          script: pip install --upgrade streamlit && sudo supervisorctl restart picker && streamlit cache clear


### PR DESCRIPTION
When you deploy or upgrade streamlit, the supervisor process needs to be restarted.

The process for this project is `picker`, not `streamlit` - so this change needs to be put in so that the proper supervisor process is restarted after deployment etc.